### PR TITLE
Fix manifest.json to point to the right icons

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,9 +4,9 @@
   "description": "Identify and resolve Trusted Types violations easily!",
   "version": "1.0",
   "icons": {
-    "16": "t16.png",
-    "48": "t48.png",
-    "128": "t128.png"
+    "16": "images/t16.png",
+    "48": "images/t48.png",
+    "128": "images/t128.png"
   },
   "action": {
     "default_popup": "popup.html"


### PR DESCRIPTION
The previous commit was missing the `images/` prefix.